### PR TITLE
Fixes build error and length warnings.

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -15,8 +15,9 @@
 \usepackage{tikz}
 \usepackage{helvet}
 \usepackage{hyphenat}
+\usepackage{url}
 \renewcommand{\familydefault}{\sfdefault}
-\def\checkmark{\tikz\fill[scale=0.4](0,.35) -- (.25,0) -- (1,.7) -- (.25,.15) -- cycle;} 
+\def\checkmark{\tikz\fill[scale=0.4](0,.35) -- (.25,0) -- (1,.7) -- (.25,.15) -- cycle;}
 \pagestyle{fancy}
 \fancyhf{}
 \fancyhead[LE, RO]{\thepage}
@@ -27,6 +28,7 @@
 \bibpunct{(}{)}{,}{a}{}{ }
 \graphicspath{ {images/}{appendices/} }
 \footskip = 15mm
+
 
 \begin{document}
 
@@ -76,8 +78,8 @@ Wordcount goes here
 
 \input{chapters/chapter05}
 
-\input{chapters/Conclusion}
-\nocite{*} %Take this out if you don't want it to show all the references and only the ones you've referenced 
+\input{chapters/conclusion}
+\nocite{*} %Take this out if you don't want it to show all the references and only the ones you've referenced
 \bibliography{references}
 
 

--- a/references.bib
+++ b/references.bib
@@ -12,13 +12,13 @@
   title={Ubuntu Security},
   author={Ubuntu},
   year={2012},
-  note={Available From: https://help.ubuntu.com/community/Security [Accessed: 2015-05-01]}, 
+  note={\\\url{https://help.ubuntu.com/community/Security [Accessed: 2015-05-01]}}
 }
 
 
 @inproceedings{iacob17,
   title={Using Extreme Characters to Teach Requirements Engineering},
-  author={Iacob, C., and Faily, S.},
+  author={Iacob, C. and Faily, S.},
   booktitle={Proceedings of the IEEE Conference on Software Engineering Education and Training},
   year={2017},
   organization={IEEE}


### PR DESCRIPTION
Build error caused by incorrect chapter input and warnings from URL/References.

Building using texlive and latexmk on Ubuntu 18.04.3 LTS.

![latex_builds](https://user-images.githubusercontent.com/10119462/66058170-ca32dd00-e531-11e9-90c9-36013c33d393.PNG)
